### PR TITLE
Add image and video media filters

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -223,6 +223,8 @@ export default function App() {
         found = mergeLocatedEvents(eventChunks.flat());
       }
 
+      const relayCount = found.length;
+
       if (hasImage || hasVideo) {
         found = found.filter((note) =>
           matchesMediaFilters(note, hasImage, hasVideo)
@@ -231,7 +233,7 @@ export default function App() {
 
       if (found.length === 0) {
         let text = "No notes found.";
-        if (hasImage || hasVideo) {
+        if ((hasImage || hasVideo) && relayCount > 0) {
           text =
             fromDate || toDate
               ? "No matching notes in this range (latest 200). Try a different date range."

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,7 @@ import {
   searchProfiles,
   shouldSuggestProfiles,
 } from "./profile-search";
+import { matchesMediaFilters } from "./media";
 import {
   AUTHOR_CHUNK_SIZE,
   chunkArray,
@@ -43,6 +44,8 @@ const INCLUDE_FOLLOWED_USERS_QUERY_PARAM = "followed";
 const INCLUDE_ONLY_AUTHOR_QUERY_PARAM = "onlyAuthor";
 const INCLUDE_ONLY_NOTES_AUTHOR_REACTED_TO_QUERY_PARAM =
   "onlyNotesAuthorReactedTo";
+
+const queryFlagEnabled = (value: string | null) => value === "1";
 
 async function resolveSubmittedIdentity(raw: string): Promise<NostrIdentity> {
   const input = raw.trim();
@@ -72,6 +75,12 @@ export default function App() {
   const [query, setQuery] = useState(queryParams.get("query") ?? "");
   const [fromDate, setFromDate] = useState(queryParams.get("fromDate") ?? "");
   const [toDate, setToDate] = useState(queryParams.get("toDate") ?? "");
+  const [hasImage, setHasImage] = useState(
+    queryFlagEnabled(queryParams.get("hasImage"))
+  );
+  const [hasVideo, setHasVideo] = useState(
+    queryFlagEnabled(queryParams.get("hasVideo"))
+  );
   const [events, setEvents] = useState<LocatedEvent[]>([]);
   const [currentDataLength, setCurrentDataLength] = useState(0);
   const [openNote, setOpenNote] = useState<LocatedEvent | null>(null);
@@ -125,6 +134,14 @@ export default function App() {
     updateQueryParams("include", value);
     setInclude(value);
   };
+
+  const handleMediaFilterChange =
+    (key: "hasImage" | "hasVideo", set: Dispatch<SetStateAction<boolean>>) =>
+    (event: ChangeEvent<HTMLInputElement>) => {
+      const checked = event.target.checked;
+      updateQueryParams(key, checked ? "1" : "");
+      set(checked);
+    };
 
   const handleSubmit = async (event?: FormEvent<HTMLFormElement>) => {
     event?.preventDefault();
@@ -206,8 +223,21 @@ export default function App() {
         found = mergeLocatedEvents(eventChunks.flat());
       }
 
+      if (hasImage || hasVideo) {
+        found = found.filter((note) =>
+          matchesMediaFilters(note, hasImage, hasVideo)
+        );
+      }
+
       if (found.length === 0) {
-        setMessage({ text: "No notes found.", tone: "info" });
+        let text = "No notes found.";
+        if (hasImage || hasVideo) {
+          text =
+            fromDate || toDate
+              ? "No matching notes in this range (latest 200). Try a different date range."
+              : "No matching notes in the latest 200. Try a from/to date.";
+        }
+        setMessage({ text, tone: "info" });
       }
 
       setCurrentDataLength(Math.min(5, found.length));
@@ -232,6 +262,8 @@ export default function App() {
     setQuery("");
     setFromDate("");
     setToDate("");
+    setHasImage(false);
+    setHasVideo(false);
     setEvents([]);
     setCurrentDataLength(0);
     setOpenNote(null);
@@ -356,6 +388,28 @@ export default function App() {
           </div>
         </div>
 
+        <fieldset className="include-set" disabled={isSearching}>
+          <legend>Media</legend>
+          <label className="radio-row">
+            <input
+              type="checkbox"
+              name="hasImage"
+              checked={hasImage}
+              onChange={handleMediaFilterChange("hasImage", setHasImage)}
+            />
+            <span>Has image</span>
+          </label>
+          <label className="radio-row">
+            <input
+              type="checkbox"
+              name="hasVideo"
+              checked={hasVideo}
+              onChange={handleMediaFilterChange("hasVideo", setHasVideo)}
+            />
+            <span>Has video</span>
+          </label>
+        </fieldset>
+
         <div className="actions">
           <button type="button" className="secondary" onClick={handleClear}>
             Clear
@@ -389,7 +443,7 @@ export default function App() {
               {formatCreateAtDate(note.created_at)}
             </time>
             <div className="note-body">
-              <NoteContent content={note.content} />
+              <NoteContent content={note.content} tags={note.tags} />
             </div>
           </li>
         ))}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -234,10 +234,16 @@ export default function App() {
       if (found.length === 0) {
         let text = "No notes found.";
         if ((hasImage || hasVideo) && relayCount > 0) {
+          const media =
+            hasImage && hasVideo
+              ? "image or video"
+              : hasImage
+                ? "image"
+                : "video";
           text =
             fromDate || toDate
-              ? "No matching notes in this range (latest 200). Try a different date range."
-              : "No matching notes in the latest 200. Try a from/to date.";
+              ? `None of the notes in this range (latest ${NOTE_LIMIT}) have a detectable ${media}.`
+              : `None of the latest ${NOTE_LIMIT} notes have a detectable ${media}.`;
         }
         setMessage({ text, tone: "info" });
       }

--- a/src/NoteContent.tsx
+++ b/src/NoteContent.tsx
@@ -1,14 +1,21 @@
 import { Fragment } from "react";
+import {
+  classifyUrl,
+  hyperlinkRegex,
+  newlineRegex,
+  normalizeHttpUrl,
+} from "./media";
 
-const newlineRegex = /(\r?\n)/gi;
-const hyperlinkRegex = /(https?:\/\/[^\s]+)/gi;
 const wavlakeRegex =
   /(https?:\/\/(?:player\.|www\.)?wavlake\.com\/(?!top|new|artists|account|activity|login|preferences|feed|profile|shows)(?:(?:track|album)\/[a-f0-9]{8}(?:-[a-f0-9]{4}){3}-[a-f0-9]{12}|[a-z-]+))/gi;
-const imageUrlRegex =
-  /(https?:\/\/.*\.(?:png|jpg|jpeg|jfif|gif|bmp|svg|webp))/gi;
-const videoUrlRegex = /(https?:\/\/.*\.(?:mp4|mov|ogg|webm|mkv|avi|m4v))/gi;
 
-export const NoteContent = ({ content }: { content: string }) => {
+export const NoteContent = ({
+  content,
+  tags = [],
+}: {
+  content: string;
+  tags?: string[][];
+}) => {
   const parts = content.split(
     new RegExp(`(?:${newlineRegex.source}|${hyperlinkRegex.source})`, "gi")
   );
@@ -24,7 +31,7 @@ export const NoteContent = ({ content }: { content: string }) => {
           return <br key={index} />;
         }
 
-        if (part.match(wavlakeRegex)) {
+        if (/^https?:\/\//i.test(part) && part.match(wavlakeRegex)) {
           const convertedUrl = part.replace(
             /(?:player\.|www\.)?wavlake\.com/,
             "embed.wavlake.com"
@@ -41,23 +48,42 @@ export const NoteContent = ({ content }: { content: string }) => {
           );
         }
 
-        if (part.match(imageUrlRegex)) {
+        if (!/^https?:\/\//i.test(part)) {
+          return <Fragment key={index}>{part}</Fragment>;
+        }
+
+        const url = normalizeHttpUrl(part);
+        const media = classifyUrl(url, tags);
+
+        if (media === "image") {
           return (
-            <img key={index} className="note-image" src={part} alt="" />
+            <img
+              key={index}
+              className="note-image"
+              src={url}
+              alt=""
+              loading="lazy"
+            />
           );
         }
 
-        if (part.match(videoUrlRegex)) {
+        if (media === "video") {
           return (
-            <video key={index} className="note-video" src={part} controls>
-              {part}
+            <video
+              key={index}
+              className="note-video"
+              src={url}
+              controls
+              preload="none"
+            >
+              {url}
             </video>
           );
         }
 
         if (part.match(hyperlinkRegex)) {
           return (
-            <a key={index} href={part} target="_blank" rel="noreferrer">
+            <a key={index} href={url} target="_blank" rel="noreferrer">
               {part}
             </a>
           );

--- a/src/NoteContent.tsx
+++ b/src/NoteContent.tsx
@@ -69,13 +69,7 @@ export const NoteContent = ({
 
         if (media === "video") {
           return (
-            <video
-              key={index}
-              className="note-video"
-              src={url}
-              controls
-              preload="none"
-            >
+            <video key={index} className="note-video" src={url} controls>
               {url}
             </video>
           );

--- a/src/media.ts
+++ b/src/media.ts
@@ -58,14 +58,30 @@ export function parseImeta(tags: string[][] = []): Imeta[] {
   return entries;
 }
 
-function pathnameExtension(url: string): string | undefined {
+function extensionFromFilename(name: string): string | undefined {
+  const last = name.split("/").pop() ?? "";
+  const dot = last.lastIndexOf(".");
+  if (dot <= 0) return undefined;
+  return last.slice(dot + 1).toLowerCase();
+}
+
+/** Path first, then query values/keys like `?file=clip.mp4`. */
+function urlMediaKind(url: string): MediaKind | null {
   try {
-    const last = new URL(url).pathname.split("/").pop() ?? "";
-    const dot = last.lastIndexOf(".");
-    if (dot <= 0) return undefined;
-    return last.slice(dot + 1).toLowerCase();
+    const parsed = new URL(url);
+    const fromPath = extensionKind(extensionFromFilename(parsed.pathname));
+    if (fromPath) return fromPath;
+
+    for (const [key, value] of parsed.searchParams) {
+      const fromValue = extensionKind(extensionFromFilename(value));
+      if (fromValue) return fromValue;
+      const fromKey = extensionKind(extensionFromFilename(key));
+      if (fromKey) return fromKey;
+    }
+
+    return null;
   } catch {
-    return undefined;
+    return null;
   }
 }
 
@@ -112,7 +128,7 @@ export function classifyUrl(url: string, tags: string[][] = []): MediaKind | nul
     }
   }
 
-  const fromExt = extensionKind(pathnameExtension(normalized));
+  const fromExt = urlMediaKind(normalized);
   if (fromExt) return fromExt;
 
   // Extensionless blossom blobs are usually images in kind 1 notes.

--- a/src/media.ts
+++ b/src/media.ts
@@ -136,18 +136,6 @@ export function collectMediaKinds(note: NoteMedia): Set<MediaKind> {
     if (kind) kinds.add(kind);
   }
 
-  for (const entry of parseImeta(tags)) {
-    if (entry.mime) {
-      const kind = mimeKind(entry.mime);
-      if (kind) kinds.add(kind);
-      continue;
-    }
-    if (entry.url) {
-      const kind = classifyUrl(entry.url, tags);
-      if (kind) kinds.add(kind);
-    }
-  }
-
   return kinds;
 }
 

--- a/src/media.ts
+++ b/src/media.ts
@@ -1,0 +1,173 @@
+export type MediaKind = "image" | "video";
+
+export const newlineRegex = /(\r?\n)/gi;
+export const hyperlinkRegex = /(https?:\/\/[^\s]+)/gi;
+
+const IMAGE_EXTENSIONS = new Set([
+  "png",
+  "jpg",
+  "jpeg",
+  "jfif",
+  "gif",
+  "bmp",
+  "svg",
+  "webp",
+  "avif",
+  "heic",
+  "heif",
+]);
+
+const VIDEO_EXTENSIONS = new Set([
+  "mp4",
+  "mov",
+  "ogg",
+  "webm",
+  "mkv",
+  "avi",
+  "m4v",
+]);
+
+const BLOSSOM_SEGMENT_RE = /^([a-fA-F0-9]{64})(?:\.([a-zA-Z0-9]+))?$/;
+
+type Imeta = { url?: string; mime?: string };
+
+type NoteMedia = { content: string; tags?: string[][] };
+
+/** Strip punctuation that `https?:\/\/[^\s]+` often captures from surrounding prose. */
+export function normalizeHttpUrl(raw: string): string {
+  return raw.replace(/[),.;:!?]+$/g, "");
+}
+
+export function parseImeta(tags: string[][] = []): Imeta[] {
+  const entries: Imeta[] = [];
+
+  for (const tag of tags) {
+    if (tag[0] !== "imeta") continue;
+    const entry: Imeta = {};
+    for (let i = 1; i < tag.length; i++) {
+      const space = tag[i].indexOf(" ");
+      if (space <= 0) continue;
+      const key = tag[i].slice(0, space);
+      const value = tag[i].slice(space + 1);
+      if (key === "url") entry.url = value;
+      if (key === "m") entry.mime = value;
+    }
+    if (entry.url || entry.mime) entries.push(entry);
+  }
+
+  return entries;
+}
+
+function pathnameExtension(url: string): string | undefined {
+  try {
+    const last = new URL(url).pathname.split("/").pop() ?? "";
+    const dot = last.lastIndexOf(".");
+    if (dot <= 0) return undefined;
+    return last.slice(dot + 1).toLowerCase();
+  } catch {
+    return undefined;
+  }
+}
+
+/** BUD-01 / NIP-B7: last path segment is a SHA-256, with an optional advisory extension. */
+export function blossomHashFromUrl(url: string): string | undefined {
+  try {
+    const last = new URL(url).pathname.split("/").filter(Boolean).pop() ?? "";
+    const match = last.match(BLOSSOM_SEGMENT_RE);
+    return match?.[1]?.toLowerCase();
+  } catch {
+    return undefined;
+  }
+}
+
+function mimeKind(mime: string): MediaKind | null {
+  if (mime.startsWith("image/")) return "image";
+  if (mime.startsWith("video/")) return "video";
+  return null;
+}
+
+function extensionKind(ext: string | undefined): MediaKind | null {
+  if (!ext) return null;
+  if (IMAGE_EXTENSIONS.has(ext)) return "image";
+  if (VIDEO_EXTENSIONS.has(ext)) return "video";
+  return null;
+}
+
+function urlsMatch(a: string, b: string): boolean {
+  if (a === b) return true;
+  const hashA = blossomHashFromUrl(a);
+  const hashB = blossomHashFromUrl(b);
+  return Boolean(hashA && hashB && hashA === hashB);
+}
+
+export function classifyUrl(url: string, tags: string[][] = []): MediaKind | null {
+  const normalized = normalizeHttpUrl(url);
+  const imeta = parseImeta(tags);
+
+  for (const entry of imeta) {
+    if (!entry.url || !urlsMatch(normalized, entry.url)) continue;
+    if (entry.mime) {
+      const fromMime = mimeKind(entry.mime);
+      if (fromMime) return fromMime;
+    }
+  }
+
+  const fromExt = extensionKind(pathnameExtension(normalized));
+  if (fromExt) return fromExt;
+
+  // Extensionless blossom blobs are usually images in kind 1 notes.
+  if (blossomHashFromUrl(normalized)) return "image";
+
+  return null;
+}
+
+function urlsInContent(content: string): string[] {
+  return [...content.matchAll(new RegExp(hyperlinkRegex.source, "gi"))].map(
+    (match) => normalizeHttpUrl(match[0])
+  );
+}
+
+export function collectMediaKinds(note: NoteMedia): Set<MediaKind> {
+  const kinds = new Set<MediaKind>();
+  const tags = note.tags ?? [];
+
+  for (const url of urlsInContent(note.content)) {
+    const kind = classifyUrl(url, tags);
+    if (kind) kinds.add(kind);
+  }
+
+  for (const entry of parseImeta(tags)) {
+    if (entry.mime) {
+      const kind = mimeKind(entry.mime);
+      if (kind) kinds.add(kind);
+      continue;
+    }
+    if (entry.url) {
+      const kind = classifyUrl(entry.url, tags);
+      if (kind) kinds.add(kind);
+    }
+  }
+
+  return kinds;
+}
+
+export function noteHasImage(note: NoteMedia): boolean {
+  return collectMediaKinds(note).has("image");
+}
+
+export function noteHasVideo(note: NoteMedia): boolean {
+  return collectMediaKinds(note).has("video");
+}
+
+/** Both filters on → image OR video. */
+export function matchesMediaFilters(
+  note: NoteMedia,
+  hasImage: boolean,
+  hasVideo: boolean
+): boolean {
+  if (!hasImage && !hasVideo) return true;
+  const kinds = collectMediaKinds(note);
+  if (hasImage && hasVideo) return kinds.has("image") || kinds.has("video");
+  if (hasImage) return kinds.has("image");
+  return kinds.has("video");
+}

--- a/src/media.ts
+++ b/src/media.ts
@@ -125,6 +125,9 @@ export function classifyUrl(url: string, tags: string[][] = []): MediaKind | nul
     if (entry.mime) {
       const fromMime = mimeKind(entry.mime);
       if (fromMime) return fromMime;
+      // Authoritative non-image/video MIME (e.g. audio/mpeg): do not guess via
+      // extension or the extensionless blossom heuristic.
+      return null;
     }
   }
 


### PR DESCRIPTION
## Summary
- Add Has image / Has video checkboxes that filter search results (OR when both are on) and persist via `hasImage` / `hasVideo` query params
- Classify media from note content using file extensions, NIP-92 `imeta` MIME types, and extensionless blossom hashes so notes without a file suffix still match
- Render images and videos in notes with the same classification, including lazy-loaded images and tag-aware MIME types

## Test plan
- [ ] Search without media filters and confirm results look the same as before
- [ ] Enable Has image and confirm only notes with a detectable image remain; empty state mentions images when relays returned notes that were filtered out
- [ ] Enable Has video (alone and together with Has image) and confirm OR matching when both are on
- [ ] Reload a URL with `hasImage=1` and/or `hasVideo=1` and confirm the checkboxes restore
- [ ] Clear the form and confirm both media filters reset
- [ ] Open notes with extensionless blossom image URLs, `imeta` MIME types, and query-param media URLs and confirm they render as image/video (not plain links)


Made with [Cursor](https://cursor.com)