### PR TITLE
Show author and mention profiles in search results

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,12 +11,19 @@ import * as nip19 from "nostr-tools/nip19";
 import type { Filter } from "nostr-tools/filter";
 import { NoteContent } from "./NoteContent";
 import { IdentityCombobox } from "./IdentityCombobox";
+import { Avatar } from "./Avatar";
 import {
   NoteMenuIcon,
   OpenInDialog,
   type OpenInTarget,
 } from "./OpenInDialog";
-import { collectMentionIdentities } from "./mentions";
+import {
+  addIdentities,
+  collectMentionIdentities,
+  isUnmodifiedLeftClick,
+  njumpProfileHref,
+  profileLabel,
+} from "./mentions";
 import {
   IdentityError,
   resolveIdentity,
@@ -70,6 +77,64 @@ async function resolveSubmittedIdentity(raw: string): Promise<NostrIdentity> {
     }
   }
   return resolveIdentity(input);
+}
+
+function encodeNpub(pubkey: string): string {
+  try {
+    return nip19.npubEncode(pubkey);
+  } catch {
+    return "";
+  }
+}
+
+function NoteAuthor({
+  pubkey,
+  createdAt,
+  profile,
+  onOpenProfile,
+}: {
+  pubkey: string;
+  createdAt: number;
+  profile?: Kind0Profile;
+  onOpenProfile: (code: string) => void;
+}) {
+  const code = encodeNpub(pubkey);
+  const name = profileLabel(pubkey, profile?.displayName);
+  const timestamp = (
+    <time dateTime={new Date(createdAt * 1000).toISOString()}>
+      {formatCreateAtDate(createdAt)}
+    </time>
+  );
+
+  const body = (
+    <>
+      <Avatar src={profile?.picture} />
+      <span className="note-author-copy">
+        <span className="note-author-name">{name}</span>
+        {timestamp}
+      </span>
+    </>
+  );
+
+  if (!code) {
+    return <div className="note-author">{body}</div>;
+  }
+
+  return (
+    <a
+      className="note-author"
+      href={njumpProfileHref(code)}
+      target="_blank"
+      rel="noreferrer"
+      onClick={(event) => {
+        if (!isUnmodifiedLeftClick(event)) return;
+        event.preventDefault();
+        onOpenProfile(code);
+      }}
+    >
+      {body}
+    </a>
+  );
 }
 
 export default function App() {
@@ -312,10 +377,16 @@ export default function App() {
   const visibleEvents = events.slice(0, currentDataLength);
 
   useEffect(() => {
-    const identities = collectMentionIdentities(
-      events.slice(0, currentDataLength).map((note) => note.content)
+    const visible = events.slice(0, currentDataLength);
+    if (visible.length === 0) return;
+
+    const identities = addIdentities(
+      collectMentionIdentities(visible.map((note) => note.content)),
+      visible.map((note) => ({
+        pubkey: note.pubkey,
+        relayHints: note.seenOn.filter((url) => url.startsWith("wss://")),
+      }))
     );
-    if (identities.length === 0) return;
 
     let cancelled = false;
     void getKind0Profiles(identities).then((found) => {
@@ -484,9 +555,14 @@ export default function App() {
             >
               <NoteMenuIcon />
             </button>
-            <time dateTime={new Date(note.created_at * 1000).toISOString()}>
-              {formatCreateAtDate(note.created_at)}
-            </time>
+            <NoteAuthor
+              pubkey={note.pubkey}
+              createdAt={note.created_at}
+              profile={profiles[note.pubkey.toLowerCase()]}
+              onOpenProfile={(code) =>
+                setOpenTarget({ kind: "profile", code })
+              }
+            />
             <div className="note-body">
               <NoteContent
                 content={note.content}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,7 +21,7 @@ import {
   addIdentities,
   collectMentionIdentities,
   isUnmodifiedLeftClick,
-  njumpProfileHref,
+  njumpHref,
   profileLabel,
 } from "./mentions";
 import {
@@ -36,6 +36,7 @@ import {
   shouldSuggestProfiles,
 } from "./profile-search";
 import { matchesMediaFilters } from "./media";
+import { encodeNevent } from "./nostr-clients";
 import {
   AUTHOR_CHUNK_SIZE,
   chunkArray,
@@ -123,7 +124,7 @@ function NoteAuthor({
   return (
     <a
       className="note-author"
-      href={njumpProfileHref(code)}
+      href={njumpHref(code)}
       target="_blank"
       rel="noreferrer"
       onClick={(event) => {
@@ -551,7 +552,11 @@ export default function App() {
               aria-haspopup="dialog"
               aria-label="Open this note in…"
               title="Open this note in…"
-              onClick={() => setOpenTarget({ kind: "note", note })}
+              onClick={() => {
+                try {
+                  setOpenTarget({ kind: "note", code: encodeNevent(note) });
+                } catch {}
+              }}
             >
               <NoteMenuIcon />
             </button>
@@ -568,9 +573,7 @@ export default function App() {
                 content={note.content}
                 tags={note.tags}
                 profiles={profiles}
-                onOpenProfile={(code) =>
-                  setOpenTarget({ kind: "profile", code })
-                }
+                onOpen={(kind, code) => setOpenTarget({ kind, code })}
               />
             </div>
           </li>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,10 +11,16 @@ import * as nip19 from "nostr-tools/nip19";
 import type { Filter } from "nostr-tools/filter";
 import { NoteContent } from "./NoteContent";
 import { IdentityCombobox } from "./IdentityCombobox";
-import { NoteMenuIcon, OpenInDialog } from "./OpenInDialog";
+import {
+  NoteMenuIcon,
+  OpenInDialog,
+  type OpenInTarget,
+} from "./OpenInDialog";
+import { collectMentionIdentities } from "./mentions";
 import {
   IdentityError,
   resolveIdentity,
+  type Kind0Profile,
   type NostrIdentity,
 } from "./identity";
 import {
@@ -32,6 +38,7 @@ import {
   findNotes,
   formatCreateAtDate,
   getFollowedPubkeys,
+  getKind0Profiles,
   getUserReactionEventIds,
   getUserRelays,
   mergeLocatedEvents,
@@ -83,7 +90,10 @@ export default function App() {
   );
   const [events, setEvents] = useState<LocatedEvent[]>([]);
   const [currentDataLength, setCurrentDataLength] = useState(0);
-  const [openNote, setOpenNote] = useState<LocatedEvent | null>(null);
+  const [openTarget, setOpenTarget] = useState<OpenInTarget | null>(null);
+  const [profiles, setProfiles] = useState<Record<string, Kind0Profile>>(
+    {}
+  );
   const [message, setMessage] = useState<{
     text: string;
     tone: "error" | "info";
@@ -274,7 +284,8 @@ export default function App() {
     setHasVideo(false);
     setEvents([]);
     setCurrentDataLength(0);
-    setOpenNote(null);
+    setOpenTarget(null);
+    setProfiles({});
     setMessage(null);
   };
 
@@ -299,6 +310,32 @@ export default function App() {
   }, [currentDataLength, events.length]);
 
   const visibleEvents = events.slice(0, currentDataLength);
+
+  useEffect(() => {
+    const identities = collectMentionIdentities(
+      events.slice(0, currentDataLength).map((note) => note.content)
+    );
+    if (identities.length === 0) return;
+
+    let cancelled = false;
+    void getKind0Profiles(identities).then((found) => {
+      if (cancelled) return;
+      setProfiles((prev) => {
+        let changed = false;
+        const next = { ...prev };
+        for (const [pubkey, profile] of Object.entries(found)) {
+          if (prev[pubkey] === profile) continue;
+          next[pubkey] = profile;
+          changed = true;
+        }
+        return changed ? next : prev;
+      });
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [events, currentDataLength]);
 
   return (
     <main className="page">
@@ -443,7 +480,7 @@ export default function App() {
               aria-haspopup="dialog"
               aria-label="Open this note in…"
               title="Open this note in…"
-              onClick={() => setOpenNote(note)}
+              onClick={() => setOpenTarget({ kind: "note", note })}
             >
               <NoteMenuIcon />
             </button>
@@ -451,15 +488,25 @@ export default function App() {
               {formatCreateAtDate(note.created_at)}
             </time>
             <div className="note-body">
-              <NoteContent content={note.content} tags={note.tags} />
+              <NoteContent
+                content={note.content}
+                tags={note.tags}
+                profiles={profiles}
+                onOpenProfile={(code) =>
+                  setOpenTarget({ kind: "profile", code })
+                }
+              />
             </div>
           </li>
         ))}
       </ol>
       <div ref={sentinelRef} className="sentinel" aria-hidden="true" />
 
-      {openNote ? (
-        <OpenInDialog note={openNote} onClose={() => setOpenNote(null)} />
+      {openTarget ? (
+        <OpenInDialog
+          target={openTarget}
+          onClose={() => setOpenTarget(null)}
+        />
       ) : null}
     </main>
   );

--- a/src/Avatar.tsx
+++ b/src/Avatar.tsx
@@ -1,0 +1,25 @@
+import { useEffect, useState } from "react";
+
+export function Avatar({ src }: { src?: string }) {
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    setFailed(false);
+  }, [src]);
+
+  if (!src || failed) {
+    return <span className="avatar avatar-empty" aria-hidden="true" />;
+  }
+
+  return (
+    <img
+      className="avatar"
+      src={src}
+      alt=""
+      referrerPolicy="no-referrer"
+      decoding="async"
+      loading="lazy"
+      onError={() => setFailed(true)}
+    />
+  );
+}

--- a/src/IdentityCombobox.tsx
+++ b/src/IdentityCombobox.tsx
@@ -5,6 +5,7 @@ import {
   useState,
   type KeyboardEvent,
 } from "react";
+import { Avatar } from "./Avatar";
 import {
   SEARCH_DEBOUNCE_MS,
   searchProfiles,
@@ -12,31 +13,6 @@ import {
   suggestionValue,
   type ProfileSuggestion,
 } from "./profile-search";
-
-function SuggestAvatar({ src }: { src?: string }) {
-  const [failed, setFailed] = useState(false);
-
-  useEffect(() => {
-    setFailed(false);
-  }, [src]);
-
-  if (!src || failed) {
-    return (
-      <span className="suggest-avatar suggest-avatar-empty" aria-hidden="true" />
-    );
-  }
-
-  return (
-    <img
-      className="suggest-avatar"
-      src={src}
-      alt=""
-      referrerPolicy="no-referrer"
-      decoding="async"
-      onError={() => setFailed(true)}
-    />
-  );
-}
 
 type IdentityComboboxProps = {
   id: string;
@@ -236,7 +212,7 @@ export function IdentityCombobox({
             onMouseDown={(event) => event.preventDefault()}
             onClick={() => selectSuggestion(index)}
           >
-            <SuggestAvatar src={item.picture} />
+            <Avatar src={item.picture} />
             <span className="suggest-copy">
               <span className="suggest-name">
                 {item.displayName?.trim() || `${item.npub.slice(0, 16)}…`}

--- a/src/NoteContent.tsx
+++ b/src/NoteContent.tsx
@@ -6,13 +6,15 @@ import {
   normalizeHttpUrl,
 } from "./media";
 import {
-  mentionLabel,
-  mentionRegex,
-  njumpProfileHref,
-  parseMention,
   isUnmodifiedLeftClick,
+  mentionLabel,
+  njumpHref,
+  noteRefLabel,
+  nostrUriRegex,
+  parseNostrEntity,
 } from "./mentions";
 import type { Kind0Profile } from "./identity";
+import type { OpenInKind } from "./nostr-clients";
 
 const wavlakeRegex =
   /(https?:\/\/(?:player\.|www\.)?wavlake\.com\/(?!top|new|artists|account|activity|login|preferences|feed|profile|shows)(?:(?:track|album)\/[a-f0-9]{8}(?:-[a-f0-9]{4}){3}-[a-f0-9]{12}|[a-z-]+))/gi;
@@ -21,16 +23,16 @@ export const NoteContent = ({
   content,
   tags = [],
   profiles = {},
-  onOpenProfile,
+  onOpen,
 }: {
   content: string;
   tags?: string[][];
   profiles?: Record<string, Kind0Profile>;
-  onOpenProfile?: (code: string) => void;
+  onOpen?: (kind: OpenInKind, code: string) => void;
 }) => {
   const parts = content.split(
     new RegExp(
-      `(?:${newlineRegex.source}|${mentionRegex.source}|${hyperlinkRegex.source})`,
+      `(?:${newlineRegex.source}|${nostrUriRegex.source}|${hyperlinkRegex.source})`,
       "gi"
     )
   );
@@ -46,26 +48,32 @@ export const NoteContent = ({
           return <br key={index} />;
         }
 
-        const mention = parseMention(part);
-        if (mention) {
+        const entity = parseNostrEntity(part);
+        if (entity) {
+          const kind: OpenInKind = entity.type === "profile" ? "profile" : "note";
+          const label =
+            entity.type === "profile"
+              ? mentionLabel(
+                  entity.pubkey,
+                  profiles[entity.pubkey]?.displayName
+                )
+              : noteRefLabel(entity.code);
+
           return (
             <a
               key={index}
               className="note-mention"
-              href={njumpProfileHref(mention.code)}
+              href={njumpHref(entity.code)}
               target="_blank"
               rel="noreferrer"
               onClick={(event) => {
-                if (!onOpenProfile) return;
+                if (!onOpen) return;
                 if (!isUnmodifiedLeftClick(event)) return;
                 event.preventDefault();
-                onOpenProfile(mention.code);
+                onOpen(kind, entity.code);
               }}
             >
-              {mentionLabel(
-                mention.pubkey,
-                profiles[mention.pubkey]?.displayName
-              )}
+              {label}
             </a>
           );
         }

--- a/src/NoteContent.tsx
+++ b/src/NoteContent.tsx
@@ -10,6 +10,7 @@ import {
   mentionRegex,
   njumpProfileHref,
   parseMention,
+  isUnmodifiedLeftClick,
 } from "./mentions";
 import type { Kind0Profile } from "./identity";
 
@@ -56,15 +57,7 @@ export const NoteContent = ({
               rel="noreferrer"
               onClick={(event) => {
                 if (!onOpenProfile) return;
-                if (
-                  event.button !== 0 ||
-                  event.metaKey ||
-                  event.ctrlKey ||
-                  event.shiftKey ||
-                  event.altKey
-                ) {
-                  return;
-                }
+                if (!isUnmodifiedLeftClick(event)) return;
                 event.preventDefault();
                 onOpenProfile(mention.code);
               }}

--- a/src/NoteContent.tsx
+++ b/src/NoteContent.tsx
@@ -5,6 +5,13 @@ import {
   newlineRegex,
   normalizeHttpUrl,
 } from "./media";
+import {
+  mentionLabel,
+  mentionRegex,
+  njumpProfileHref,
+  parseMention,
+} from "./mentions";
+import type { Kind0Profile } from "./identity";
 
 const wavlakeRegex =
   /(https?:\/\/(?:player\.|www\.)?wavlake\.com\/(?!top|new|artists|account|activity|login|preferences|feed|profile|shows)(?:(?:track|album)\/[a-f0-9]{8}(?:-[a-f0-9]{4}){3}-[a-f0-9]{12}|[a-z-]+))/gi;
@@ -12,12 +19,19 @@ const wavlakeRegex =
 export const NoteContent = ({
   content,
   tags = [],
+  profiles = {},
+  onOpenProfile,
 }: {
   content: string;
   tags?: string[][];
+  profiles?: Record<string, Kind0Profile>;
+  onOpenProfile?: (code: string) => void;
 }) => {
   const parts = content.split(
-    new RegExp(`(?:${newlineRegex.source}|${hyperlinkRegex.source})`, "gi")
+    new RegExp(
+      `(?:${newlineRegex.source}|${mentionRegex.source}|${hyperlinkRegex.source})`,
+      "gi"
+    )
   );
 
   return (
@@ -29,6 +43,38 @@ export const NoteContent = ({
 
         if (part.match(newlineRegex)) {
           return <br key={index} />;
+        }
+
+        const mention = parseMention(part);
+        if (mention) {
+          return (
+            <a
+              key={index}
+              className="note-mention"
+              href={njumpProfileHref(mention.code)}
+              target="_blank"
+              rel="noreferrer"
+              onClick={(event) => {
+                if (!onOpenProfile) return;
+                if (
+                  event.button !== 0 ||
+                  event.metaKey ||
+                  event.ctrlKey ||
+                  event.shiftKey ||
+                  event.altKey
+                ) {
+                  return;
+                }
+                event.preventDefault();
+                onOpenProfile(mention.code);
+              }}
+            >
+              {mentionLabel(
+                mention.pubkey,
+                profiles[mention.pubkey]?.displayName
+              )}
+            </a>
+          );
         }
 
         if (/^https?:\/\//i.test(part) && part.match(wavlakeRegex)) {

--- a/src/OpenInDialog.tsx
+++ b/src/OpenInDialog.tsx
@@ -1,17 +1,16 @@
 import { useEffect, useId, useRef } from "react";
-import type { LocatedEvent } from "./nostr";
 import {
   clientHref,
   clientsForPlatform,
   detectClientPlatform,
-  encodeNevent,
   isWebClientHref,
   type OpenInKind,
 } from "./nostr-clients";
 
-export type OpenInTarget =
-  | { kind: "note"; note: LocatedEvent }
-  | { kind: "profile"; code: string };
+export type OpenInTarget = {
+  kind: OpenInKind;
+  code: string;
+};
 
 export function NoteMenuIcon() {
   return (
@@ -23,14 +22,6 @@ export function NoteMenuIcon() {
   );
 }
 
-function targetCode(target: OpenInTarget): string {
-  try {
-    return target.kind === "note" ? encodeNevent(target.note) : target.code;
-  } catch {
-    return "";
-  }
-}
-
 export function OpenInDialog({
   target,
   onClose,
@@ -40,8 +31,7 @@ export function OpenInDialog({
 }) {
   const dialogRef = useRef<HTMLDialogElement>(null);
   const titleId = useId();
-  const code = targetCode(target);
-  const kind: OpenInKind = target.kind;
+  const { kind, code } = target;
   const clients = clientsForPlatform(detectClientPlatform());
   const onCloseRef = useRef(onClose);
   onCloseRef.current = onClose;

--- a/src/OpenInDialog.tsx
+++ b/src/OpenInDialog.tsx
@@ -6,7 +6,12 @@ import {
   detectClientPlatform,
   encodeNevent,
   isWebClientHref,
+  type OpenInKind,
 } from "./nostr-clients";
+
+export type OpenInTarget =
+  | { kind: "note"; note: LocatedEvent }
+  | { kind: "profile"; code: string };
 
 export function NoteMenuIcon() {
   return (
@@ -18,21 +23,25 @@ export function NoteMenuIcon() {
   );
 }
 
+function targetCode(target: OpenInTarget): string {
+  try {
+    return target.kind === "note" ? encodeNevent(target.note) : target.code;
+  } catch {
+    return "";
+  }
+}
+
 export function OpenInDialog({
-  note,
+  target,
   onClose,
 }: {
-  note: LocatedEvent;
+  target: OpenInTarget;
   onClose: () => void;
 }) {
   const dialogRef = useRef<HTMLDialogElement>(null);
   const titleId = useId();
-  let nevent = "";
-  try {
-    nevent = encodeNevent(note);
-  } catch {
-    nevent = "";
-  }
+  const code = targetCode(target);
+  const kind: OpenInKind = target.kind;
   const clients = clientsForPlatform(detectClientPlatform());
   const onCloseRef = useRef(onClose);
   onCloseRef.current = onClose;
@@ -50,7 +59,7 @@ export function OpenInDialog({
     };
   }, []);
 
-  if (!nevent) return null;
+  if (!code) return null;
 
   return (
     <dialog
@@ -66,7 +75,7 @@ export function OpenInDialog({
       </h2>
       <div className="open-in-list">
         {clients.map((client, index) => {
-          const href = clientHref(client, nevent);
+          const href = clientHref(client, code, kind);
           return (
             <a
               key={client.id}

--- a/src/index.css
+++ b/src/index.css
@@ -227,7 +227,7 @@ input:focus-visible {
   background: var(--signal-soft);
 }
 
-.suggest-avatar {
+.avatar {
   flex: none;
   width: 2rem;
   height: 2rem;
@@ -236,7 +236,7 @@ input:focus-visible {
   background: var(--paper);
 }
 
-.suggest-avatar-empty {
+.avatar-empty {
   display: block;
   border: 1px solid var(--line);
 }
@@ -374,9 +374,37 @@ input:focus-visible {
   border-left: 3px solid var(--signal);
 }
 
+.note-author {
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+  min-width: 0;
+  margin: 0 0 0.75rem;
+  color: inherit;
+  text-decoration: none;
+}
+
+.note-author-copy {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.12rem;
+}
+
+.note-author-name {
+  font-weight: 600;
+  line-height: 1.25;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.note-author:hover .note-author-name {
+  text-decoration: underline;
+}
+
 .note time {
   display: block;
-  margin-bottom: 0.65rem;
   font-family: var(--font-mono);
   font-size: 0.78rem;
   color: var(--muted);

--- a/src/index.css
+++ b/src/index.css
@@ -391,6 +391,15 @@ input:focus-visible {
   color: var(--signal);
 }
 
+.note-mention {
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.note-mention:hover {
+  text-decoration: underline;
+}
+
 .note-image,
 .note-video,
 .note-embed {

--- a/src/mentions.ts
+++ b/src/mentions.ts
@@ -1,0 +1,88 @@
+import { nip19 } from "nostr-tools";
+
+/** NIP-27 npub / nprofile, with or without the `nostr:` prefix. */
+export const mentionRegex =
+  /((?:nostr:)?n(?:pub|profile)1[02-9ac-hj-np-z]+)/gi;
+
+export type Mention = {
+  code: string;
+  pubkey: string;
+  relayHints: string[];
+};
+
+export type MentionIdentity = {
+  pubkey: string;
+  relayHints: string[];
+};
+
+function stripNostrPrefix(raw: string): string {
+  return raw.toLowerCase().startsWith("nostr:") ? raw.slice(6) : raw;
+}
+
+export function parseMention(raw: string): Mention | null {
+  const input = raw.trim();
+  if (!/^(?:nostr:)?n(?:pub|profile)1[02-9ac-hj-np-z]+$/i.test(input)) {
+    return null;
+  }
+
+  const code = stripNostrPrefix(input).toLowerCase();
+
+  try {
+    const decoded = nip19.decode(code);
+    if (decoded.type === "npub") {
+      return { code, pubkey: decoded.data.toLowerCase(), relayHints: [] };
+    }
+    if (decoded.type === "nprofile") {
+      return {
+        code,
+        pubkey: decoded.data.pubkey.toLowerCase(),
+        relayHints: (decoded.data.relays ?? [])
+          .map((url) => url.replace(/\/+$/, ""))
+          .filter((url) => url.startsWith("wss://")),
+      };
+    }
+  } catch {
+    return null;
+  }
+
+  return null;
+}
+
+export function collectMentionIdentities(
+  contents: string[]
+): MentionIdentity[] {
+  const byPubkey = new Map<string, string[]>();
+
+  for (const content of contents) {
+    for (const match of content.matchAll(new RegExp(mentionRegex.source, "gi"))) {
+      const mention = parseMention(match[0]);
+      if (!mention) continue;
+
+      const relays = byPubkey.get(mention.pubkey) ?? [];
+      for (const url of mention.relayHints) {
+        if (!relays.includes(url)) relays.push(url);
+      }
+      byPubkey.set(mention.pubkey, relays);
+    }
+  }
+
+  return [...byPubkey.entries()].map(([pubkey, relayHints]) => ({
+    pubkey,
+    relayHints,
+  }));
+}
+
+export function mentionLabel(pubkey: string, displayName?: string): string {
+  const name = displayName?.trim();
+  if (name) return `@${name}`;
+
+  try {
+    return `@${nip19.npubEncode(pubkey).slice(0, 16)}…`;
+  } catch {
+    return "@npub…";
+  }
+}
+
+export function njumpProfileHref(code: string): string {
+  return `https://njump.me/${code}`;
+}

--- a/src/mentions.ts
+++ b/src/mentions.ts
@@ -72,17 +72,57 @@ export function collectMentionIdentities(
   }));
 }
 
-export function mentionLabel(pubkey: string, displayName?: string): string {
+export function profileLabel(pubkey: string, displayName?: string): string {
   const name = displayName?.trim();
-  if (name) return `@${name}`;
+  if (name) return name;
 
   try {
-    return `@${nip19.npubEncode(pubkey).slice(0, 16)}…`;
+    return `${nip19.npubEncode(pubkey).slice(0, 16)}…`;
   } catch {
-    return "@npub…";
+    return "npub…";
   }
+}
+
+export function mentionLabel(pubkey: string, displayName?: string): string {
+  return `@${profileLabel(pubkey, displayName)}`;
 }
 
 export function njumpProfileHref(code: string): string {
   return `https://njump.me/${code}`;
+}
+
+export function addIdentities(
+  identities: MentionIdentity[],
+  extra: MentionIdentity[]
+): MentionIdentity[] {
+  const byPubkey = new Map<string, string[]>();
+  for (const identity of [...identities, ...extra]) {
+    const pubkey = identity.pubkey.trim().toLowerCase();
+    if (!pubkey) continue;
+    const relays = byPubkey.get(pubkey) ?? [];
+    for (const url of identity.relayHints) {
+      if (!relays.includes(url)) relays.push(url);
+    }
+    byPubkey.set(pubkey, relays);
+  }
+  return [...byPubkey.entries()].map(([pubkey, relayHints]) => ({
+    pubkey,
+    relayHints,
+  }));
+}
+
+export function isUnmodifiedLeftClick(event: {
+  button: number;
+  metaKey: boolean;
+  ctrlKey: boolean;
+  shiftKey: boolean;
+  altKey: boolean;
+}): boolean {
+  return (
+    event.button === 0 &&
+    !event.metaKey &&
+    !event.ctrlKey &&
+    !event.shiftKey &&
+    !event.altKey
+  );
 }

--- a/src/mentions.ts
+++ b/src/mentions.ts
@@ -1,14 +1,25 @@
 import { nip19 } from "nostr-tools";
 
-/** NIP-27 npub / nprofile, with or without the `nostr:` prefix. */
-export const mentionRegex =
-  /((?:nostr:)?n(?:pub|profile)1[02-9ac-hj-np-z]+)/gi;
+/** NIP-27 identifiers, with or without the `nostr:` prefix. */
+export const nostrUriRegex =
+  /((?:nostr:)?n(?:pub|profile|event|ote)1[02-9ac-hj-np-z]+)/gi;
+
+const NOSTR_URI =
+  /^(?:nostr:)?n(?:pub|profile|event|ote)1[02-9ac-hj-np-z]+$/i;
 
 export type Mention = {
+  type: "profile";
   code: string;
   pubkey: string;
   relayHints: string[];
 };
+
+export type NoteRef = {
+  type: "note";
+  code: string;
+};
+
+export type NostrEntity = Mention | NoteRef;
 
 export type MentionIdentity = {
   pubkey: string;
@@ -19,27 +30,34 @@ function stripNostrPrefix(raw: string): string {
   return raw.toLowerCase().startsWith("nostr:") ? raw.slice(6) : raw;
 }
 
-export function parseMention(raw: string): Mention | null {
+export function parseNostrEntity(raw: string): NostrEntity | null {
   const input = raw.trim();
-  if (!/^(?:nostr:)?n(?:pub|profile)1[02-9ac-hj-np-z]+$/i.test(input)) {
-    return null;
-  }
+  if (!NOSTR_URI.test(input)) return null;
 
   const code = stripNostrPrefix(input).toLowerCase();
 
   try {
     const decoded = nip19.decode(code);
     if (decoded.type === "npub") {
-      return { code, pubkey: decoded.data.toLowerCase(), relayHints: [] };
+      return {
+        type: "profile",
+        code,
+        pubkey: decoded.data.toLowerCase(),
+        relayHints: [],
+      };
     }
     if (decoded.type === "nprofile") {
       return {
+        type: "profile",
         code,
         pubkey: decoded.data.pubkey.toLowerCase(),
         relayHints: (decoded.data.relays ?? [])
           .map((url) => url.replace(/\/+$/, ""))
           .filter((url) => url.startsWith("wss://")),
       };
+    }
+    if (decoded.type === "note" || decoded.type === "nevent") {
+      return { type: "note", code };
     }
   } catch {
     return null;
@@ -48,13 +66,18 @@ export function parseMention(raw: string): Mention | null {
   return null;
 }
 
+export function parseMention(raw: string): Mention | null {
+  const entity = parseNostrEntity(raw);
+  return entity?.type === "profile" ? entity : null;
+}
+
 export function collectMentionIdentities(
   contents: string[]
 ): MentionIdentity[] {
   const byPubkey = new Map<string, string[]>();
 
   for (const content of contents) {
-    for (const match of content.matchAll(new RegExp(mentionRegex.source, "gi"))) {
+    for (const match of content.matchAll(new RegExp(nostrUriRegex.source, "gi"))) {
       const mention = parseMention(match[0]);
       if (!mention) continue;
 
@@ -87,7 +110,11 @@ export function mentionLabel(pubkey: string, displayName?: string): string {
   return `@${profileLabel(pubkey, displayName)}`;
 }
 
-export function njumpProfileHref(code: string): string {
+export function noteRefLabel(code: string): string {
+  return `${code.slice(0, 16)}…`;
+}
+
+export function njumpHref(code: string): string {
   return `https://njump.me/${code}`;
 }
 

--- a/src/nostr-clients.ts
+++ b/src/nostr-clients.ts
@@ -3,11 +3,15 @@ import type { LocatedEvent } from "./nostr";
 
 export type ClientPlatform = "android" | "ios" | "web";
 
+export type OpenInKind = "note" | "profile";
+
 export type NostrClient = {
   id: string;
   name: string;
   platform: "native" | "web" | "ios" | "android";
   url: string;
+  /** Defaults to `url`. Use when the profile path differs (e.g. Primal `/p/` vs `/e/`). */
+  profileUrl?: string;
 };
 
 /** Keep nevents shareable; extra relays mostly bloat the bech32 string. */
@@ -57,6 +61,7 @@ export const NOSTR_CLIENTS: NostrClient[] = [
     name: "Primal",
     platform: "web",
     url: "https://primal.net/e/{code}",
+    profileUrl: "https://primal.net/p/{code}",
   },
   {
     id: "coracle",
@@ -101,8 +106,13 @@ export function encodeNevent(note: LocatedEvent): string {
   });
 }
 
-export function clientHref(client: NostrClient, nevent: string): string {
-  return client.url.replaceAll("{code}", nevent);
+export function clientHref(
+  client: NostrClient,
+  code: string,
+  kind: OpenInKind = "note"
+): string {
+  const template = kind === "profile" ? (client.profileUrl ?? client.url) : client.url;
+  return template.replaceAll("{code}", code);
 }
 
 export function clientsForPlatform(platform: ClientPlatform): NostrClient[] {

--- a/src/nostr.ts
+++ b/src/nostr.ts
@@ -242,9 +242,15 @@ function extraProfileHints(relayHints: string[]): string[] {
   );
 }
 
-function rememberTriedHints(pubkey: string, relayHints: string[]) {
+function rememberTriedHints(
+  pubkey: string,
+  relayHints: string[],
+  queriedRelays: Set<string>
+) {
   const tried = kind0TriedHints.get(pubkey) ?? new Set();
-  for (const url of extraProfileHints(relayHints)) tried.add(url);
+  for (const url of extraProfileHints(relayHints)) {
+    if (queriedRelays.has(url)) tried.add(url);
+  }
   kind0TriedHints.set(pubkey, tried);
 }
 
@@ -255,10 +261,17 @@ function needsKind0Fetch(pubkey: string, relayHints: string[]): boolean {
   return extraProfileHints(relayHints).some((url) => !tried?.has(url));
 }
 
-function profileRelaysFor(identities: { relayHints: string[] }[]): string[] {
+function profileRelaysFor(
+  identities: { pubkey: string; relayHints: string[] }[]
+): string[] {
   const base = dedupeRelays(PROFILE_METADATA_RELAYS);
-  const extra = extraProfileHints(
-    identities.flatMap((identity) => identity.relayHints)
+  const extra = dedupeRelays(
+    identities.flatMap((identity) => {
+      const tried = kind0TriedHints.get(identity.pubkey);
+      return extraProfileHints(identity.relayHints).filter(
+        (url) => !tried?.has(url)
+      );
+    })
   ).slice(0, MAX_PROFILE_HINT_RELAYS);
   return [...base, ...extra];
 }
@@ -266,11 +279,11 @@ function profileRelaysFor(identities: { relayHints: string[] }[]): string[] {
 async function loadKind0Profiles(
   identities: { pubkey: string; relayHints: string[] }[]
 ): Promise<void> {
-  for (const { pubkey, relayHints } of identities) {
-    rememberTriedHints(pubkey, relayHints);
-  }
-
   const relays = profileRelaysFor(identities);
+  const queriedRelays = new Set(relays);
+  for (const { pubkey, relayHints } of identities) {
+    rememberTriedHints(pubkey, relayHints, queriedRelays);
+  }
   const latest = new Map<string, LocatedEvent>();
 
   for (const authors of chunkArray(

--- a/src/nostr.ts
+++ b/src/nostr.ts
@@ -233,18 +233,43 @@ export async function findNotes(
 
 const kind0Cache = new Map<string, Kind0Profile | null>();
 const kind0Inflight = new Map<string, Promise<void>>();
+const kind0TriedHints = new Map<string, Set<string>>();
+const PROFILE_METADATA_RELAY_SET = new Set(PROFILE_METADATA_RELAYS);
+
+function extraProfileHints(relayHints: string[]): string[] {
+  return dedupeRelays(relayHints).filter(
+    (url) => !PROFILE_METADATA_RELAY_SET.has(url)
+  );
+}
+
+function rememberTriedHints(pubkey: string, relayHints: string[]) {
+  const tried = kind0TriedHints.get(pubkey) ?? new Set();
+  for (const url of extraProfileHints(relayHints)) tried.add(url);
+  kind0TriedHints.set(pubkey, tried);
+}
+
+function needsKind0Fetch(pubkey: string, relayHints: string[]): boolean {
+  if (kind0Cache.get(pubkey)) return false;
+  if (!kind0Cache.has(pubkey)) return true;
+  const tried = kind0TriedHints.get(pubkey);
+  return extraProfileHints(relayHints).some((url) => !tried?.has(url));
+}
 
 function profileRelaysFor(identities: { relayHints: string[] }[]): string[] {
   const base = dedupeRelays(PROFILE_METADATA_RELAYS);
-  const extra = dedupeRelays(identities.flatMap((identity) => identity.relayHints))
-    .filter((url) => !base.includes(url))
-    .slice(0, MAX_PROFILE_HINT_RELAYS);
+  const extra = extraProfileHints(
+    identities.flatMap((identity) => identity.relayHints)
+  ).slice(0, MAX_PROFILE_HINT_RELAYS);
   return [...base, ...extra];
 }
 
 async function loadKind0Profiles(
   identities: { pubkey: string; relayHints: string[] }[]
 ): Promise<void> {
+  for (const { pubkey, relayHints } of identities) {
+    rememberTriedHints(pubkey, relayHints);
+  }
+
   const relays = profileRelaysFor(identities);
   const events: LocatedEvent[] = [];
 
@@ -290,28 +315,32 @@ export async function getKind0Profiles(
     byPubkey.set(pubkey, relays);
   }
 
-  const toFetch: { pubkey: string; relayHints: string[] }[] = [];
-  const waitFor: Promise<void>[] = [];
+  for (;;) {
+    const toFetch: { pubkey: string; relayHints: string[] }[] = [];
+    const waitFor: Promise<void>[] = [];
 
-  for (const [pubkey, relayHints] of byPubkey) {
-    if (kind0Cache.has(pubkey)) continue;
-    const pending = kind0Inflight.get(pubkey);
-    if (pending) {
-      waitFor.push(pending);
-      continue;
+    for (const [pubkey, relayHints] of byPubkey) {
+      if (!needsKind0Fetch(pubkey, relayHints)) continue;
+      const pending = kind0Inflight.get(pubkey);
+      if (pending) {
+        waitFor.push(pending);
+        continue;
+      }
+      toFetch.push({ pubkey, relayHints });
     }
-    toFetch.push({ pubkey, relayHints });
-  }
 
-  if (toFetch.length > 0) {
-    const fetchPromise = loadKind0Profiles(toFetch).finally(() => {
-      for (const { pubkey } of toFetch) kind0Inflight.delete(pubkey);
-    });
-    for (const { pubkey } of toFetch) kind0Inflight.set(pubkey, fetchPromise);
-    waitFor.push(fetchPromise);
-  }
+    if (toFetch.length === 0 && waitFor.length === 0) break;
 
-  if (waitFor.length > 0) await Promise.all(waitFor);
+    if (toFetch.length > 0) {
+      const fetchPromise = loadKind0Profiles(toFetch).finally(() => {
+        for (const { pubkey } of toFetch) kind0Inflight.delete(pubkey);
+      });
+      for (const { pubkey } of toFetch) kind0Inflight.set(pubkey, fetchPromise);
+      waitFor.push(fetchPromise);
+    }
+
+    await Promise.all(waitFor);
+  }
 
   const found: Record<string, Kind0Profile> = {};
   for (const pubkey of byPubkey.keys()) {

--- a/src/nostr.ts
+++ b/src/nostr.ts
@@ -1,6 +1,10 @@
 import { SimplePool, type Event, type Filter } from "nostr-tools";
+import {
+  parseKind0Profile,
+  type Kind0Profile,
+  type NostrIdentity,
+} from "./identity";
 import { VERTEX_RELAY } from "./profile-search";
-import type { NostrIdentity } from "./identity";
 
 export type LocatedEvent = Event & { seenOn: string[] };
 
@@ -20,6 +24,17 @@ export const DEFAULT_RELAYS = [
 export const FALLBACK_RELAYS = ["wss://relay.damus.io"];
 
 const DISCOVERY_RELAYS = [VERTEX_RELAY, "wss://purplepag.es"];
+
+/**
+ * Kind 0 lookups for note mentions. Vertex is omitted on purpose: its
+ * 200 events/min cap is shared with NIP-50 profile search.
+ */
+const PROFILE_METADATA_RELAYS = [
+  "wss://purplepag.es",
+  ...DEFAULT_RELAYS,
+  ...FALLBACK_RELAYS,
+];
+const MAX_PROFILE_HINT_RELAYS = 8;
 
 export const RELAY_MAX_WAIT_MS = 4500;
 export const NOTE_LIMIT = 200;
@@ -214,4 +229,94 @@ export async function findNotes(
   filter: Filter
 ): Promise<LocatedEvent[]> {
   return queryRelays(relays, filter);
+}
+
+const kind0Cache = new Map<string, Kind0Profile | null>();
+const kind0Inflight = new Map<string, Promise<void>>();
+
+function profileRelaysFor(identities: { relayHints: string[] }[]): string[] {
+  const base = dedupeRelays(PROFILE_METADATA_RELAYS);
+  const extra = dedupeRelays(identities.flatMap((identity) => identity.relayHints))
+    .filter((url) => !base.includes(url))
+    .slice(0, MAX_PROFILE_HINT_RELAYS);
+  return [...base, ...extra];
+}
+
+async function loadKind0Profiles(
+  identities: { pubkey: string; relayHints: string[] }[]
+): Promise<void> {
+  const relays = profileRelaysFor(identities);
+  const events: LocatedEvent[] = [];
+
+  for (const authors of chunkArray(
+    identities.map((identity) => identity.pubkey),
+    AUTHOR_CHUNK_SIZE
+  )) {
+    events.push(
+      ...(await queryRelays(relays, {
+        kinds: [0],
+        authors,
+        limit: authors.length,
+      }))
+    );
+  }
+
+  const latest = new Map<string, LocatedEvent>();
+  for (const event of events) {
+    if (event.kind !== 0) continue;
+    const prev = latest.get(event.pubkey.toLowerCase());
+    if (!prev || event.created_at > prev.created_at) {
+      latest.set(event.pubkey.toLowerCase(), event);
+    }
+  }
+
+  for (const { pubkey } of identities) {
+    const event = latest.get(pubkey);
+    kind0Cache.set(pubkey, event ? parseKind0Profile(event) : null);
+  }
+}
+
+export async function getKind0Profiles(
+  identities: { pubkey: string; relayHints?: string[] }[]
+): Promise<Record<string, Kind0Profile>> {
+  const byPubkey = new Map<string, string[]>();
+  for (const identity of identities) {
+    const pubkey = identity.pubkey.trim().toLowerCase();
+    if (!/^[0-9a-f]{64}$/.test(pubkey)) continue;
+    const relays = byPubkey.get(pubkey) ?? [];
+    for (const url of identity.relayHints ?? []) {
+      if (!relays.includes(url)) relays.push(url);
+    }
+    byPubkey.set(pubkey, relays);
+  }
+
+  const toFetch: { pubkey: string; relayHints: string[] }[] = [];
+  const waitFor: Promise<void>[] = [];
+
+  for (const [pubkey, relayHints] of byPubkey) {
+    if (kind0Cache.has(pubkey)) continue;
+    const pending = kind0Inflight.get(pubkey);
+    if (pending) {
+      waitFor.push(pending);
+      continue;
+    }
+    toFetch.push({ pubkey, relayHints });
+  }
+
+  if (toFetch.length > 0) {
+    const fetchPromise = loadKind0Profiles(toFetch).finally(() => {
+      for (const { pubkey } of toFetch) kind0Inflight.delete(pubkey);
+    });
+    for (const { pubkey } of toFetch) kind0Inflight.set(pubkey, fetchPromise);
+    waitFor.push(fetchPromise);
+  }
+
+  if (waitFor.length > 0) await Promise.all(waitFor);
+
+  const found: Record<string, Kind0Profile> = {};
+  for (const pubkey of byPubkey.keys()) {
+    const profile = kind0Cache.get(pubkey);
+    if (profile) found[pubkey] = profile;
+  }
+  return found;
 }

--- a/src/nostr.ts
+++ b/src/nostr.ts
@@ -367,7 +367,13 @@ export async function getKind0Profiles(
   const found: Record<string, Kind0Profile> = {};
   for (const pubkey of byPubkey.keys()) {
     const profile = kind0Cache.get(pubkey);
-    if (profile) found[pubkey] = profile;
+    if (profile) {
+      found[pubkey] = profile;
+      continue;
+    }
+    // Drop misses so a later search can retry after a relay timeout.
+    kind0Cache.delete(pubkey);
+    kind0TriedHints.delete(pubkey);
   }
   return found;
 }

--- a/src/nostr.ts
+++ b/src/nostr.ts
@@ -271,27 +271,35 @@ async function loadKind0Profiles(
   }
 
   const relays = profileRelaysFor(identities);
-  const events: LocatedEvent[] = [];
+  const latest = new Map<string, LocatedEvent>();
 
   for (const authors of chunkArray(
     identities.map((identity) => identity.pubkey),
     AUTHOR_CHUNK_SIZE
   )) {
-    events.push(
-      ...(await queryRelays(relays, {
+    // Relays treat `limit` as a total event cap, not one kind-0 per author,
+    // and may also apply their own default. Re-query whoever is still
+    // missing until a pass adds no new profiles.
+    let remaining = authors;
+    for (let pass = 0; pass < 4 && remaining.length > 0; pass++) {
+      const events = await queryRelays(relays, {
         kinds: [0],
-        authors,
-        limit: authors.length,
-      }))
-    );
-  }
+        authors: remaining,
+        limit: remaining.length,
+      });
 
-  const latest = new Map<string, LocatedEvent>();
-  for (const event of events) {
-    if (event.kind !== 0) continue;
-    const prev = latest.get(event.pubkey.toLowerCase());
-    if (!prev || event.created_at > prev.created_at) {
-      latest.set(event.pubkey.toLowerCase(), event);
+      for (const event of events) {
+        if (event.kind !== 0) continue;
+        const pubkey = event.pubkey.toLowerCase();
+        const prev = latest.get(pubkey);
+        if (!prev || event.created_at > prev.created_at) {
+          latest.set(pubkey, event);
+        }
+      }
+
+      const next = remaining.filter((pubkey) => !latest.has(pubkey));
+      if (next.length === remaining.length) break;
+      remaining = next;
     }
   }
 

--- a/src/nostr.ts
+++ b/src/nostr.ts
@@ -255,7 +255,8 @@ function rememberTriedHints(
 }
 
 function needsKind0Fetch(pubkey: string, relayHints: string[]): boolean {
-  if (kind0Cache.get(pubkey)) return false;
+  const cached = kind0Cache.get(pubkey);
+  if (cached?.picture || cached?.displayName || cached?.nip05) return false;
   if (!kind0Cache.has(pubkey)) return true;
   const tried = kind0TriedHints.get(pubkey);
   return extraProfileHints(relayHints).some((url) => !tried?.has(url));


### PR DESCRIPTION
## Summary
- Render author avatars/display names and clickable `nostr:` mentions (npub, nprofile, note, nevent) in search results, opening the existing Open In dialog for both notes and profiles.
- Fetch Kind 0 metadata with caching, relay-hint retries, and a re-query loop so profiles still resolve when relays cap `limit` across authors.
- Share a single `Avatar` component with identity search suggestions, and add a Primal profile URL template so Open In can deep-link profiles.

## Test plan
- [ ] Run a search and confirm each note shows an author avatar and display name (or truncated npub fallback).
- [ ] Click an author name: Open In appears with profile links; modifier/middle-click still opens njump.
- [ ] Click an `@mention` in note content after Kind 0 loads and confirm the label updates from truncated npub to the display name.
- [ ] Click a `note1`/`nevent1` mention and confirm Open In offers note clients.
- [ ] Confirm identity combobox suggestions still show avatars after extracting the shared `Avatar` component.
- [ ] Repeat a search for the same authors and confirm profiles resolve from cache without a visible flash of missing names.


Made with [Cursor](https://cursor.com)