### PR TITLE
Render NIP-30 custom emoji in note search results

### DIFF
--- a/src/NoteContent.tsx
+++ b/src/NoteContent.tsx
@@ -1,4 +1,4 @@
-import { Fragment } from "react";
+import { Fragment, useEffect, useState } from "react";
 import {
   classifyUrl,
   hyperlinkRegex,
@@ -13,11 +13,58 @@ import {
   nostrUriRegex,
   parseNostrEntity,
 } from "./mentions";
-import type { Kind0Profile } from "./identity";
+import { isSafeHttpUrl, type Kind0Profile } from "./identity";
 import type { OpenInKind } from "./nostr-clients";
 
 const wavlakeRegex =
   /(https?:\/\/(?:player\.|www\.)?wavlake\.com\/(?!top|new|artists|account|activity|login|preferences|feed|profile|shows)(?:(?:track|album)\/[a-f0-9]{8}(?:-[a-f0-9]{4}){3}-[a-f0-9]{12}|[a-z-]+))/gi;
+
+/** NIP-30 shortcodes: `:name:` with alphanumeric, hyphen, or underscore. */
+const customEmojiRegex = /(:[A-Za-z0-9_-]+:)/g;
+const SHORTCODE = /^[A-Za-z0-9_-]+$/;
+
+function parseEmojiTags(tags: string[][]): Map<string, string> {
+  const emojis = new Map<string, string>();
+  for (const tag of tags) {
+    if (tag[0] !== "emoji") continue;
+    const shortcode = tag[1]?.trim();
+    const url = tag[2]?.trim();
+    if (!shortcode || !SHORTCODE.test(shortcode)) continue;
+    if (!url || !isSafeHttpUrl(url)) continue;
+    emojis.set(shortcode.toLowerCase(), url);
+  }
+  return emojis;
+}
+
+function CustomEmoji({
+  shortcode,
+  src,
+}: {
+  shortcode: string;
+  src: string;
+}) {
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    setFailed(false);
+  }, [src]);
+
+  const token = `:${shortcode}:`;
+  if (failed) return token;
+
+  return (
+    <img
+      className="note-emoji"
+      src={src}
+      alt={token}
+      title={token}
+      referrerPolicy="no-referrer"
+      decoding="async"
+      loading="lazy"
+      onError={() => setFailed(true)}
+    />
+  );
+}
 
 export const NoteContent = ({
   content,
@@ -30,9 +77,12 @@ export const NoteContent = ({
   profiles?: Record<string, Kind0Profile>;
   onOpen?: (kind: OpenInKind, code: string) => void;
 }) => {
+  const emojis = parseEmojiTags(tags);
   const parts = content.split(
     new RegExp(
-      `(?:${newlineRegex.source}|${nostrUriRegex.source}|${hyperlinkRegex.source})`,
+      `(?:${newlineRegex.source}|${nostrUriRegex.source}|${hyperlinkRegex.source}${
+        emojis.size > 0 ? `|${customEmojiRegex.source}` : ""
+      })`,
       "gi"
     )
   );
@@ -91,6 +141,20 @@ export const NoteContent = ({
               src={convertedUrl}
               loading="lazy"
               title="WavLake Embed"
+            />
+          );
+        }
+
+        const emojiMatch = /^:([A-Za-z0-9_-]+):$/.exec(part);
+        const emojiUrl = emojiMatch
+          ? emojis.get(emojiMatch[1].toLowerCase())
+          : undefined;
+        if (emojiUrl && emojiMatch) {
+          return (
+            <CustomEmoji
+              key={index}
+              shortcode={emojiMatch[1]}
+              src={emojiUrl}
             />
           );
         }

--- a/src/identity.ts
+++ b/src/identity.ts
@@ -161,7 +161,7 @@ function isPrivateOrLocalHostname(hostname: string): boolean {
   return false;
 }
 
-function isSafeHttpUrl(value: string): boolean {
+export function isSafeHttpUrl(value: string): boolean {
   try {
     const url = new URL(value);
     if (url.protocol !== "https:" && url.protocol !== "http:") return false;

--- a/src/index.css
+++ b/src/index.css
@@ -428,6 +428,16 @@ input:focus-visible {
   text-decoration: underline;
 }
 
+.note-emoji {
+  display: inline-block;
+  height: 1.35em;
+  width: auto;
+  max-width: 1.8em;
+  margin: 0 0.05em;
+  object-fit: contain;
+  vertical-align: -0.25em;
+}
+
 .note-image,
 .note-video,
 .note-embed {


### PR DESCRIPTION
## Summary
- Parse NIP-30 `emoji` tags on notes and render matching `:shortcode:` tokens as inline images in search results
- Only load http/https emoji URLs that pass the existing `isSafeHttpUrl` check, and fall back to the shortcode text if the image fails

## Test plan
- [ ] Search for notes that include NIP-30 custom emoji and confirm `:shortcode:` renders as inline images
- [ ] Confirm notes without emoji tags still render the same as before
- [ ] Confirm a broken or unsafe emoji URL falls back to the `:shortcode:` text instead of a broken image


Made with [Cursor](https://cursor.com)