### PR TITLE
Tighten the search form so optional filters sit together at the bottom

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -432,51 +432,65 @@ export default function App() {
           />
         </div>
 
-        <div className="field">
-          <label htmlFor="query">Search query</label>
-          <input
-            id="query"
-            type="text"
-            placeholder="optional keywords"
-            onChange={makeInputOnChangeHandler(setQuery, "query")}
-            value={query}
-            disabled={isSearching}
-          />
-        </div>
+        <div className="filter-row">
+          <fieldset className="include-set" disabled={isSearching}>
+            <legend>Include</legend>
+            <label className="radio-row">
+              <input
+                type="radio"
+                name="include"
+                value={INCLUDE_ONLY_AUTHOR_QUERY_PARAM}
+                checked={include === INCLUDE_ONLY_AUTHOR_QUERY_PARAM}
+                onChange={(event) => handleIncludeChange(event.target.value)}
+              />
+              <span>Author notes only</span>
+            </label>
+            <label className="radio-row">
+              <input
+                type="radio"
+                name="include"
+                value={INCLUDE_ONLY_NOTES_AUTHOR_REACTED_TO_QUERY_PARAM}
+                checked={
+                  include === INCLUDE_ONLY_NOTES_AUTHOR_REACTED_TO_QUERY_PARAM
+                }
+                onChange={(event) => handleIncludeChange(event.target.value)}
+              />
+              <span>Notes the author reacted to</span>
+            </label>
+            <label className="radio-row">
+              <input
+                type="radio"
+                name="include"
+                value={INCLUDE_FOLLOWED_USERS_QUERY_PARAM}
+                checked={include === INCLUDE_FOLLOWED_USERS_QUERY_PARAM}
+                onChange={(event) => handleIncludeChange(event.target.value)}
+              />
+              <span>Author and people they follow</span>
+            </label>
+          </fieldset>
 
-        <fieldset className="include-set" disabled={isSearching}>
-          <legend>Include</legend>
-          <label className="radio-row">
-            <input
-              type="radio"
-              name="include"
-              value={INCLUDE_ONLY_AUTHOR_QUERY_PARAM}
-              checked={include === INCLUDE_ONLY_AUTHOR_QUERY_PARAM}
-              onChange={(event) => handleIncludeChange(event.target.value)}
-            />
-            <span>Author notes only</span>
-          </label>
-          <label className="radio-row">
-            <input
-              type="radio"
-              name="include"
-              value={INCLUDE_ONLY_NOTES_AUTHOR_REACTED_TO_QUERY_PARAM}
-              checked={include === INCLUDE_ONLY_NOTES_AUTHOR_REACTED_TO_QUERY_PARAM}
-              onChange={(event) => handleIncludeChange(event.target.value)}
-            />
-            <span>Notes the author reacted to</span>
-          </label>
-          <label className="radio-row">
-            <input
-              type="radio"
-              name="include"
-              value={INCLUDE_FOLLOWED_USERS_QUERY_PARAM}
-              checked={include === INCLUDE_FOLLOWED_USERS_QUERY_PARAM}
-              onChange={(event) => handleIncludeChange(event.target.value)}
-            />
-            <span>Author and people they follow</span>
-          </label>
-        </fieldset>
+          <fieldset className="include-set" disabled={isSearching}>
+            <legend>Media</legend>
+            <label className="radio-row">
+              <input
+                type="checkbox"
+                name="hasImage"
+                checked={hasImage}
+                onChange={handleMediaFilterChange("hasImage", setHasImage)}
+              />
+              <span>Has image</span>
+            </label>
+            <label className="radio-row">
+              <input
+                type="checkbox"
+                name="hasVideo"
+                checked={hasVideo}
+                onChange={handleMediaFilterChange("hasVideo", setHasVideo)}
+              />
+              <span>Has video</span>
+            </label>
+          </fieldset>
+        </div>
 
         <div className="date-row">
           <div className="field">
@@ -505,27 +519,19 @@ export default function App() {
           </div>
         </div>
 
-        <fieldset className="include-set" disabled={isSearching}>
-          <legend>Media</legend>
-          <label className="radio-row">
-            <input
-              type="checkbox"
-              name="hasImage"
-              checked={hasImage}
-              onChange={handleMediaFilterChange("hasImage", setHasImage)}
-            />
-            <span>Has image</span>
+        <div className="field">
+          <label htmlFor="query">
+            Search query <span className="optional">(optional)</span>
           </label>
-          <label className="radio-row">
-            <input
-              type="checkbox"
-              name="hasVideo"
-              checked={hasVideo}
-              onChange={handleMediaFilterChange("hasVideo", setHasVideo)}
-            />
-            <span>Has video</span>
-          </label>
-        </fieldset>
+          <input
+            id="query"
+            type="text"
+            placeholder="keywords"
+            onChange={makeInputOnChangeHandler(setQuery, "query")}
+            value={query}
+            disabled={isSearching}
+          />
+        </div>
 
         <div className="actions">
           <button type="button" className="secondary" onClick={handleClear}>

--- a/src/index.css
+++ b/src/index.css
@@ -265,8 +265,17 @@ input:focus-visible {
   white-space: nowrap;
 }
 
+.filter-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1.65fr) minmax(0, 1fr);
+  gap: 0.75rem;
+  align-items: stretch;
+}
+
 .include-set {
   margin: 0;
+  min-width: 0;
+  min-inline-size: 0;
   padding: 0.85rem 1rem 1rem;
   border: 1px solid var(--line);
   border-radius: 12px;
@@ -284,6 +293,7 @@ input:focus-visible {
   display: flex;
   gap: 0.65rem;
   align-items: flex-start;
+  min-width: 0;
   line-height: 1.35;
   cursor: pointer;
 }
@@ -554,6 +564,7 @@ a.open-in-link:focus-visible {
 
 @media (max-width: 560px) {
   .date-row,
+  .filter-row,
   .actions {
     grid-template-columns: 1fr;
     flex-direction: column;


### PR DESCRIPTION
## Summary
- Groups Include and Media filters in one row so the form reads as author → scope → dates → optional query.
- Moves the keyword field below the date range and labels it as optional.
- Stacks the filter row on narrow screens so the layout still works on mobile.

## Test plan
- [ ] Open the search form and confirm Include and Media sit side by side on desktop.
- [ ] Confirm the keyword field is below the date range and still updates the URL query param.
- [ ] Toggle Include radios and Media checkboxes; search and clear still work as before.
- [ ] Resize below 560px and confirm the filter row stacks into a single column.


Made with [Cursor](https://cursor.com)