### PR TITLE
Fix text search missing recent author notes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -49,6 +49,7 @@ import {
   getKind0Profiles,
   getUserReactionEventIds,
   getUserRelays,
+  matchesSearchQuery,
   mergeLocatedEvents,
   NOTE_LIMIT,
   NOTE_SEARCH_RELAYS,
@@ -281,13 +282,15 @@ export default function App() {
         kinds: [1],
         limit: NOTE_LIMIT,
       };
-      if (fields.query) defaultKindOneFilter.search = fields.query;
       if (fields.fromDate) {
         defaultKindOneFilter.since = convertDateToUnixTimestamp(fields.fromDate);
       }
       if (fields.toDate) {
         defaultKindOneFilter.until = convertDateToUnixTimestamp(fields.toDate);
       }
+      const searchFilter: Filter | undefined = fields.query
+        ? { ...defaultKindOneFilter, search: fields.query }
+        : undefined;
 
       let found: LocatedEvent[] = [];
 
@@ -300,15 +303,17 @@ export default function App() {
 
         if (reactionEventIds.length > 0) {
           const userRelays = await getUserRelays(identity);
-          const relays = [
-            ...(fields.query ? NOTE_SEARCH_RELAYS : []),
-            ...userRelays,
-            ...DEFAULT_RELAYS,
-          ];
+          const relays = [...userRelays, ...DEFAULT_RELAYS];
           const chunks = await Promise.all(
-            chunkArray(reactionEventIds, AUTHOR_CHUNK_SIZE).map((ids) =>
-              findNotes(relays, { ...defaultKindOneFilter, ids })
-            )
+            chunkArray(reactionEventIds, AUTHOR_CHUNK_SIZE).flatMap((ids) => {
+              const jobs = [findNotes(relays, { ...defaultKindOneFilter, ids })];
+              if (searchFilter) {
+                jobs.push(
+                  findNotes(NOTE_SEARCH_RELAYS, { ...searchFilter, ids })
+                );
+              }
+              return jobs;
+            })
           );
           found = mergeLocatedEvents(chunks.flat());
         }
@@ -320,23 +325,41 @@ export default function App() {
           ? [...followedAuthorPubkeys, identity.pubkey]
           : [identity.pubkey];
         const dedupedAuthors = Array.from(new Set(authors));
-        const userRelays = fields.query ? [] : await getUserRelays(identity);
-        const relays = fields.query
-          ? NOTE_SEARCH_RELAYS
-          : userRelays.length > 0
+        const userRelays = await getUserRelays(identity);
+        const authorRelays =
+          userRelays.length > 0
             ? [...userRelays, ...DEFAULT_RELAYS]
             : [...DEFAULT_RELAYS, ...FALLBACK_RELAYS];
 
         const eventChunks = await Promise.all(
-          chunkArray(dedupedAuthors, AUTHOR_CHUNK_SIZE).map((authorsChunk) =>
-            findNotes(relays, {
-              ...defaultKindOneFilter,
-              authors: authorsChunk,
-            })
+          chunkArray(dedupedAuthors, AUTHOR_CHUNK_SIZE).flatMap(
+            (authorsChunk) => {
+              const jobs = [
+                findNotes(authorRelays, {
+                  ...defaultKindOneFilter,
+                  authors: authorsChunk,
+                }),
+              ];
+              if (searchFilter) {
+                jobs.push(
+                  findNotes(NOTE_SEARCH_RELAYS, {
+                    ...searchFilter,
+                    authors: authorsChunk,
+                  })
+                );
+              }
+              return jobs;
+            }
           )
         );
 
         found = mergeLocatedEvents(eventChunks.flat());
+      }
+
+      if (fields.query) {
+        found = found.filter((note) =>
+          matchesSearchQuery(note, fields.query)
+        );
       }
 
       const relayCount = found.length;

--- a/src/nostr.ts
+++ b/src/nostr.ts
@@ -231,6 +231,16 @@ export async function findNotes(
   return queryRelays(relays, filter);
 }
 
+/** Case-insensitive substring match on note content. Relays often ignore or reject NIP-50 `search`. */
+export function matchesSearchQuery(
+  note: { content: string },
+  query: string
+): boolean {
+  const term = query.trim().toLowerCase();
+  if (!term) return true;
+  return note.content.toLowerCase().includes(term);
+}
+
 const kind0Cache = new Map<string, Kind0Profile | null>();
 const kind0Inflight = new Map<string, Promise<void>>();
 const kind0TriedHints = new Map<string, Set<string>>();


### PR DESCRIPTION
## Summary
- Text queries were sent only to NIP-50 search relays, which often have no index for a note even when it is on the author’s relays (e.g. `pullup` vs `wen pullup quest?`).
- Author and reaction searches now load notes from user/default relays, filter content locally, and still query NIP-50 in parallel for older indexed matches.

## Test plan
- [ ] Search author `npub1vp8fdcyejd4pqjyrjk9sgz68vuhq7pyvnzk8j0ehlljvwgp8n6eqsrnpsw` with query `pullup` and confirm `wen pullup quest?` appears.
- [ ] Same author with an empty query still lists recent notes.
- [ ] A query that does not appear in recent notes still returns no false positives.
- [ ] Optional: search notes the author reacted to with a query and confirm results still match the text.


Made with [Cursor](https://cursor.com)