### PR TITLE
Add Ditto as a NIP-50 note search relay

### DIFF
--- a/.cursor/skills/nip-50-search-test/SKILL.md
+++ b/.cursor/skills/nip-50-search-test/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: nip-50-search-test
+description: Queries Nostr NIP-50 search relays with a text query (optional author npub/hex) and reports whether matching kind-1 notes come back. Use when testing NIP-50 search results, verifying a search relay index, checking relay.noswhere.com or search.nos.today, or confirming a note is findable by search after a rebroadcast.
+---
+
+# NIP-50 search test
+
+Live-query search relays. Do not infer index state from memory or from ordinary (non-`search`) REQ results.
+
+## Run
+
+From the repo root (needs `nostr-tools` from this project):
+
+```bash
+node .cursor/skills/nip-50-search-test/scripts/nip50-search.mjs --query pullup --npub npub1...
+```
+
+Flags:
+
+- `--query` (required) — NIP-50 `search` string
+- `--npub` or `--author` (hex) — optional `authors` filter
+- `--relay` — repeatable; default is `wss://relay.ditto.pub`, `wss://relay.noswhere.com`, and `wss://search.nos.today`
+- `--limit` (default 20), `--max-wait` (default 6000)
+
+Needs network (`full_network`). Read-only: REQ plus NIP-11 HTTP. Do not EVENT/rebroadcast unless the user asked.
+
+## Interpret
+
+- `returned: 0` and a clean EOSE means the relay has no indexed hit (or does not store that event). Treat as a miss.
+- `returned > 0` but `contentIncludesQuery: 0` means the relay ignored `search` or ranked poorly — not a real NIP-50 hit.
+- Compare with a normal REQ (`ids` / `authors` without `search`) on a write relay (e.g. ditto, primal) only to prove the note exists somewhere. That does not prove the search index.
+
+## Report
+
+Lead with hit or miss per relay. Include query, author, counts, and a content preview of any matches. Mention NIP-11 `supported_nips` if 50 is missing.

--- a/.cursor/skills/nip-50-search-test/scripts/nip50-search.mjs
+++ b/.cursor/skills/nip-50-search-test/scripts/nip50-search.mjs
@@ -39,7 +39,13 @@ if (!query) {
 let author = arg("author")?.toLowerCase();
 const npub = arg("npub");
 if (!author && npub) {
-  const decoded = nip19.decode(npub);
+  let decoded;
+  try {
+    decoded = nip19.decode(npub);
+  } catch {
+    console.error("--npub is not a valid bech32 npub");
+    process.exit(1);
+  }
   if (decoded.type !== "npub") {
     console.error("--npub must decode to npub");
     process.exit(1);

--- a/.cursor/skills/nip-50-search-test/scripts/nip50-search.mjs
+++ b/.cursor/skills/nip-50-search-test/scripts/nip50-search.mjs
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+/**
+ * Probe NIP-50 search on one or more relays.
+ * Usage:
+ *   node nip50-search.mjs --query pullup --npub npub1...
+ *   node nip50-search.mjs --query pullup --author <hex> --relay wss://relay.noswhere.com
+ */
+import { SimplePool } from "nostr-tools";
+import * as nip19 from "nostr-tools/nip19";
+
+const DEFAULT_RELAYS = [
+  "wss://relay.ditto.pub",
+  "wss://relay.noswhere.com",
+  "wss://search.nos.today",
+];
+
+function arg(name, fallback) {
+  const i = process.argv.indexOf(`--${name}`);
+  if (i === -1 || !process.argv[i + 1]) return fallback;
+  return process.argv[i + 1];
+}
+
+function allArgs(name) {
+  const values = [];
+  for (let i = 0; i < process.argv.length; i++) {
+    if (process.argv[i] === `--${name}` && process.argv[i + 1]) {
+      values.push(process.argv[++i]);
+    }
+  }
+  return values;
+}
+
+const query = (arg("query") ?? "").trim();
+if (!query) {
+  console.error("Missing --query");
+  process.exit(1);
+}
+
+let author = arg("author")?.toLowerCase();
+const npub = arg("npub");
+if (!author && npub) {
+  const decoded = nip19.decode(npub);
+  if (decoded.type !== "npub") {
+    console.error("--npub must decode to npub");
+    process.exit(1);
+  }
+  author = decoded.data;
+}
+
+const relays = allArgs("relay");
+const targets = relays.length > 0 ? relays : DEFAULT_RELAYS;
+const limit = Number(arg("limit", "20"));
+const maxWait = Number(arg("max-wait", "6000"));
+
+const filter = { kinds: [1], search: query, limit };
+if (author) {
+  if (!/^[0-9a-f]{64}$/.test(author)) {
+    console.error("--author must be 64-char hex");
+    process.exit(1);
+  }
+  filter.authors = [author];
+}
+
+const pool = new SimplePool();
+
+async function nip11(relay) {
+  try {
+    const http = relay.replace(/^wss:/, "https:").replace(/^ws:/, "http:");
+    const res = await fetch(http, {
+      headers: { Accept: "application/nostr+json" },
+      signal: AbortSignal.timeout(4000),
+    });
+    if (!res.ok) return { error: `HTTP ${res.status}` };
+    const j = await res.json();
+    return {
+      name: j.name,
+      software: j.software,
+      version: j.version,
+      supported_nips: j.supported_nips,
+    };
+  } catch (e) {
+    return { error: e.message };
+  }
+}
+
+const results = [];
+for (const relay of targets) {
+  const started = Date.now();
+  let events = [];
+  let error = null;
+  try {
+    events = await pool.querySync([relay], filter, { maxWait });
+  } catch (e) {
+    error = e.message;
+  }
+  const needle = query.toLowerCase();
+  const contentHits = events.filter((e) =>
+    (e.content ?? "").toLowerCase().includes(needle)
+  );
+  results.push({
+    relay,
+    ms: Date.now() - started,
+    error,
+    nip11: await nip11(relay),
+    returned: events.length,
+    contentIncludesQuery: contentHits.length,
+    notes: events.slice(0, 8).map((e) => ({
+      id: e.id,
+      created_at: e.created_at,
+      iso: new Date(e.created_at * 1000).toISOString(),
+      contentPreview: (e.content ?? "").slice(0, 120),
+      contentMatch: (e.content ?? "").toLowerCase().includes(needle),
+    })),
+  });
+}
+
+pool.destroy();
+console.log(
+  JSON.stringify({ query, author: author ?? null, filter, results }, null, 2)
+);

--- a/src/nostr.ts
+++ b/src/nostr.ts
@@ -10,6 +10,7 @@ export type LocatedEvent = Event & { seenOn: string[] };
 
 /** NIP-50 kind 1 search. Vertex indexes profiles, not notes. */
 export const NOTE_SEARCH_RELAYS = [
+  "wss://relay.ditto.pub",
   "wss://relay.noswhere.com",
   "wss://search.nos.today",
 ];


### PR DESCRIPTION
## Summary
- Include `wss://relay.ditto.pub` in the NIP-50 kind-1 search relay list.
- Add a Cursor skill that probes search relays with a live NIP-50 query (optional author npub/hex) and reports hits vs misses.
- Invalid `--npub` input now exits with a clear error instead of throwing from `nip19.decode`.

## Test plan
- [ ] Run a note search in the app and confirm Ditto is queried alongside noswhere and nos.today.
- [ ] From repo root: `node .cursor/skills/nip-50-search-test/scripts/nip50-search.mjs --query pullup` (needs network).
- [ ] Confirm a garbage `--npub` prints `--npub is not a valid bech32 npub` and exits 1.


Made with [Cursor](https://cursor.com)