### PR TITLE
Keep more recent searches in a scrollable, filterable drawer

### DIFF
--- a/src/RecentsDrawer.tsx
+++ b/src/RecentsDrawer.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useRef, type ReactNode } from "react";
+import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import {
+  matchesRecentFilter,
   recentSummary,
   recentTitle,
   toQueryString,
@@ -27,6 +28,15 @@ export function RecentsDrawer({
   children: ReactNode;
 }) {
   const closeRef = useRef<HTMLButtonElement>(null);
+  const [filter, setFilter] = useState("");
+  const visibleRecents = useMemo(
+    () => recents.filter((recent) => matchesRecentFilter(recent, filter)),
+    [recents, filter]
+  );
+
+  useEffect(() => {
+    if (!open) setFilter("");
+  }, [open]);
 
   useEffect(() => {
     if (!open) return;
@@ -98,23 +108,37 @@ export function RecentsDrawer({
 
         {recents.length > 0 ? (
           <div className="drawer-body">
-            <ul className="recents-list">
-              {recents.map((recent) => (
-                <li key={toQueryString(recent)}>
-                  <button
-                    type="button"
-                    className="recent-link"
-                    disabled={isSearching}
-                    onClick={() => onRestore(recent)}
-                  >
-                    <span className="recent-title">{recentTitle(recent)}</span>
-                    <span className="recent-summary">
-                      {recentSummary(recent)}
-                    </span>
-                  </button>
-                </li>
-              ))}
-            </ul>
+            <label className="recents-filter">
+              <span className="visually-hidden">Filter recent searches</span>
+              <input
+                type="search"
+                value={filter}
+                placeholder="Filter recents"
+                autoComplete="off"
+                onChange={(event) => setFilter(event.target.value)}
+              />
+            </label>
+            {visibleRecents.length > 0 ? (
+              <ul className="recents-list">
+                {visibleRecents.map((recent) => (
+                  <li key={toQueryString(recent)}>
+                    <button
+                      type="button"
+                      className="recent-link"
+                      disabled={isSearching}
+                      onClick={() => onRestore(recent)}
+                    >
+                      <span className="recent-title">{recentTitle(recent)}</span>
+                      <span className="recent-summary">
+                        {recentSummary(recent)}
+                      </span>
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p className="drawer-empty">No matching searches.</p>
+            )}
             <button
               type="button"
               className="recents-clear"

--- a/src/index.css
+++ b/src/index.css
@@ -133,6 +133,18 @@ summary:focus-visible {
   color: var(--muted);
 }
 
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .drawer-empty {
   margin: 0.65rem 0.45rem 0;
   color: var(--muted);
@@ -145,7 +157,12 @@ summary:focus-visible {
   flex-direction: column;
   flex: 1;
   min-height: 0;
-  overflow: auto;
+  overflow: hidden;
+}
+
+.drawer-body .drawer-empty {
+  flex: 1;
+  min-height: 0;
 }
 
 .drawer-footer {
@@ -153,9 +170,28 @@ summary:focus-visible {
   padding-top: 1rem;
 }
 
+.recents-filter {
+  position: relative;
+  flex-shrink: 0;
+  margin: 0 0.15rem 0.4rem;
+}
+
+.recents-filter input {
+  width: 100%;
+  padding: 0.45rem 0.6rem;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--white);
+  font: inherit;
+  font-size: 0.88rem;
+  color: var(--ink);
+  appearance: none;
+}
+
 .recents-clear {
+  flex-shrink: 0;
   align-self: flex-start;
-  margin: 0.15rem 0.45rem 0.65rem;
+  margin: 0.35rem 0.45rem 0.15rem;
   padding: 0.2rem 0.15rem;
   border: none;
   background: none;
@@ -187,10 +223,13 @@ summary:focus-visible {
 
 .recents-list {
   list-style: none;
-  margin: 0.2rem 0 0;
+  margin: 0;
   padding: 0;
   display: flex;
   flex-direction: column;
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
 }
 
 .recent-link {

--- a/src/recent-searches.ts
+++ b/src/recent-searches.ts
@@ -7,7 +7,7 @@ export const INCLUDE_ONLY_NOTES_AUTHOR_REACTED_TO_QUERY_PARAM =
   "onlyNotesAuthorReactedTo";
 
 export const RECENT_SEARCHES_STORAGE_KEY = "advancednostrsearch:recents";
-export const MAX_RECENT_SEARCHES = 10;
+export const MAX_RECENT_SEARCHES = 200;
 
 export type SearchFields = {
   npub: string;
@@ -62,6 +62,27 @@ export function recentTitle(recent: RecentSearch): string {
   if (name) return name;
   const npub = recent.npub.trim();
   return npub.length > 16 ? `${npub.slice(0, 16)}…` : npub || "Unknown author";
+}
+
+export function matchesRecentFilter(
+  recent: RecentSearch,
+  filter: string
+): boolean {
+  const tokens = filter
+    .trim()
+    .toLowerCase()
+    .split(/\s+/)
+    .filter(Boolean);
+  if (tokens.length === 0) return true;
+  const haystack = [
+    recentTitle(recent),
+    recentSummary(recent),
+    recent.npub,
+    recent.query,
+  ]
+    .join(" ")
+    .toLowerCase();
+  return tokens.every((token) => haystack.includes(token));
 }
 
 export function recentSummary(recent: RecentSearch): string {


### PR DESCRIPTION
## Summary
- Raise the recent-search cap from 10 to 200 so history is not thrown away so quickly.
- Add a filter field and make the list scroll while keeping Clear pinned at the bottom of the drawer.

## Test plan
- [ ] Open recent searches with a handful of items and confirm the filter matches author, npub, query, and summary text.
- [ ] With a long list, scroll the recents and confirm Clear stays visible (does not scroll away).
- [ ] Filter until there are no matches and confirm Clear is still shown.
- [ ] Close and reopen the drawer and confirm the filter is cleared.


Made with [Cursor](https://cursor.com)